### PR TITLE
RSDK-9546: Use github repo address instead of local go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module analog-devices
+module github.com/viam-modules/analog-devices
 
 go 1.23.0
 

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ package main
 import (
 	"context"
 
-	"analog-devices/adxl345"
-	"analog-devices/tmc5072"
+	"github.com/viam-modules/analog-devices/adxl345"
+	"github.com/viam-modules/analog-devices/tmc5072"
 
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/components/movementsensor"


### PR DESCRIPTION
want to confirm this is the only necessary change. will replicate this on all other modules I maintain.

successfully built locally with this change