### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ On the new component panel, copy and paste the following attribute template into
 {
   "spi_bus": "<your-spi-bus-index>",
   "chip_select": "<pin-number>",
-  "index": "<your-terminal-index>",
+  "index": <your-terminal-index>,
   "pins": {
     "en_low": "<int>"
   },

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ On the new component panel, copy and paste the following attribute template into
   "chip_select": "<pin-number>",
   "index": "<your-terminal-index>",
   "pins": {
-    "en_low": "<int>",
+    "en_low": "<int>"
   },
   "ticks_per_rotation": <int>,
   "max_acceleration_rpm_per_sec": <float>,


### PR DESCRIPTION
Pasting into app causes JSON validation error. Removing comma fixes it. Also index is not a string, so removed quotes around that.