### PR TITLE
Update meta.json

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -3,19 +3,19 @@
   "module_id": "viam:analog-devices",
   "visibility": "public",
   "url": "https://github.com/viam-modules/analog-devices",
-  "description": "Go module for analog-devices tmc5072 motor and analog-devices axdl345 movement sensor, compatible with Viam",
+  "description": "Go module for analog-devices tmc5072 stepper motor and analog-devices axdl345 movement sensor, compatible with Viam",
   "models": [
     {
       "api": "rdk:component:motor",
       "model": "viam:analog-devices:tmc5072",
       "markdown_link" : "README.md#configure-your-tmc5072-motor",
-      "short_description" : "motor component model driver for analog-devices tmc5072"
+      "short_description" : "stepper motor component model driver for analog-devices tmc5072"
     },
     {
       "api": "rdk:component:movement_sensor",
       "model": "viam:analog-devices:adxl345",
       "markdown_link" : "README.md#configure-your-adxl345-movement-sensor",
-      "short_description" : "movement sensor compnent model driver for analog-devices adxl345"
+      "short_description" : "movement sensor component model driver for analog-devices adxl345"
     }
   ],
   "build": {


### PR DESCRIPTION
so that when people search "stepper" they'll find this
Someone asked "do you have cheaper alternative to control multipme stepper motors with a nvidia jetson than the DMC-40x0 driver?"